### PR TITLE
openMarchéForain 2.3.2 => 2.4.0

### DIFF
--- a/demonstration.inc.php
+++ b/demonstration.inc.php
@@ -128,12 +128,12 @@ $demos["openmarcheforain"] = array(
     "categories" => array(
     ),
     "versions" => array(
-        "2.3" => array(
-            "title" => "2.3.2",
+        "2.4" => array(
+            "title" => "2.4.0",
             "framework" => "4.6.3",
-            "href" => "a/openmarcheforain/2.3",
+            "href" => "a/openmarcheforain/2.4",
             "autoinstall" => true,
-            "svn" => "svn://scm.adullact.net/svn/openmarchefor/tags/2.3.2",
+            "svn" => "svn://scm.adullact.net/svn/openmarchefor/tags/2.4.0",
             "db" => "pgsql",
             "schema" => "openmf",
         ),


### PR DESCRIPTION
Devrait résoudre le problème du jeu de données constaté depuis le 01.01.2018 sur la 2.3.2